### PR TITLE
`~I` sigil to ease slots creation and some cosmetics

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -30,7 +30,6 @@ jobs:
         run: |
           mix local.rebar --force
           mix local.hex --force
-          mix do deps.get, compile
-          mix compile
+          mix do deps.get, deps.compile, compile
       - name: "Run quality tests"
         run: mix quality.ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
           elixir-version: ${{matrix.pair.elixir}}
       - name: Install → Compile dependencies
         run: |
+          mix local.rebar --force
+          mix local.hex --force
           mix do deps.get, deps.compile, compile
       - name: Run tests
         run: |

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :tempus, :fancy_inspect, true

--- a/lib/sigils.ex
+++ b/lib/sigils.ex
@@ -1,0 +1,43 @@
+defmodule Tempus.Sigils do
+  @moduledoc "Handy sigils to instantiate `Tempus.Slot`"
+
+  alias Tempus.Slot
+
+  @doc ~S"""
+  Handles the sigil `~I` for `Tempus.Slot`.
+  It returns a slot without interpolations and without escape
+  characters, except for the escaping of the closing sigil character
+  itself.
+
+  ## Examples
+      iex> import Tempus.Sigils
+      iex> ~I(2021-03-30T06:35:40Z|2021-03-30T06:36:00Z)
+      %Tempus.Slot{from: ~U[2021-03-30 06:35:40Z], to: ~U[2021-03-30 06:36:00Z]}
+      iex> ~I(2021-03-30|2021-03-31)d
+      %Tempus.Slot{from: ~U[2021-03-30 00:00:00.000000Z], to: ~U[2021-03-31 23:59:59.999999Z]}
+      iex> ~I(2021-03-30)d
+      %Tempus.Slot{from: ~U[2021-03-30 00:00:00.000000Z], to: ~U[2021-03-30 23:59:59.999999Z]}
+
+  """
+  defmacro sigil_I({:<<>>, _, [binary]}, modifiers) when is_binary(binary) do
+    module =
+      case modifiers do
+        [?d] -> Date
+        [?t] -> Time
+        [] -> DateTime
+      end
+
+    from_iso = &(&1 |> module.from_iso8601() |> elem(1) |> Slot.wrap())
+
+    result =
+      binary
+      |> String.split("|")
+      |> case do
+        [part] -> from_iso.(part)
+        [_, _] = interval -> interval |> Enum.map(from_iso) |> Slot.join()
+      end
+      |> Macro.escape()
+
+    quote(generated: true, location: :keep, do: unquote(result))
+  end
+end

--- a/lib/slot.ex
+++ b/lib/slot.ex
@@ -420,7 +420,7 @@ defmodule Tempus.Slot do
 
     def inspect(%Tempus.Slot{from: from, to: to}, opts) do
       opts.custom_options
-      |> Keyword.get(:fancy_inspect, @fancy_inspect)
+      |> Keyword.get(:fancy, @fancy_inspect)
       |> if do
         value =
           [from, to]

--- a/lib/slot.ex
+++ b/lib/slot.ex
@@ -416,6 +416,7 @@ defmodule Tempus.Slot do
 
   defimpl Inspect do
     import Inspect.Algebra
+    # credo:disable-for-next-line
     @fancy_inspect Application.get_env(:tempus, :fancy_inspect, false)
 
     def inspect(%Tempus.Slot{from: from, to: to}, opts) do

--- a/lib/slot.ex
+++ b/lib/slot.ex
@@ -176,9 +176,16 @@ defmodule Tempus.Slot do
 
       iex> Tempus.Slot.join([Tempus.Slot.wrap(~D|2020-09-30|), Tempus.Slot.wrap(~D|2020-10-02|)])
       #Slot<[from: ~U[2020-09-30 00:00:00.000000Z], to: ~U[2020-10-02 23:59:59.999999Z]]>
+
+      iex> Tempus.Slot.join([~D|2020-09-30|, ~D|2020-10-02|])
+      #Slot<[from: ~U[2020-09-30 00:00:00.000000Z], to: ~U[2020-10-02 23:59:59.999999Z]]>
   """
-  def join(slots) do
-    Enum.reduce(slots, fn slot, acc ->
+  def join([]), do: %Slot{from: nil, to: nil}
+
+  def join([slot | slots]) do
+    Enum.reduce(slots, wrap(slot), fn slot, acc ->
+      slot = wrap(slot)
+
       from =
         if DateTime.compare(slot.from, acc.from) == :lt,
           do: slot.from,
@@ -287,7 +294,7 @@ defmodule Tempus.Slot do
       iex> Tempus.Slot.wrap(~D|2020-08-06|)
       #Slot<[from: ~U[2020-08-06 00:00:00.000000Z], to: ~U[2020-08-06 23:59:59.999999Z]]>
   """
-  def wrap(moment, origin \\ DateTime.utc_now())
+  def wrap(moment \\ nil, origin \\ DateTime.utc_now())
 
   def wrap(nil, origin), do: wrap(DateTime.utc_now(), origin)
   def wrap(%Slot{} = slot, _), do: slot
@@ -409,9 +416,21 @@ defmodule Tempus.Slot do
 
   defimpl Inspect do
     import Inspect.Algebra
+    @fancy_inspect Application.get_env(:tempus, :fancy_inspect, false)
 
     def inspect(%Tempus.Slot{from: from, to: to}, opts) do
-      concat(["#Slot<", to_doc([from: from, to: to], opts), ">"])
+      opts.custom_options
+      |> Keyword.get(:fancy_inspect, @fancy_inspect)
+      |> if do
+        value =
+          [from, to]
+          |> Enum.map(&DateTime.to_iso8601/1)
+          |> Enum.join(" → ")
+
+        concat(["⌚<", value, ">"])
+      else
+        concat(["#Slot<", to_doc([from: from, to: to], opts), ">"])
+      end
     end
   end
 end

--- a/lib/slot.ex
+++ b/lib/slot.ex
@@ -419,19 +419,31 @@ defmodule Tempus.Slot do
     # credo:disable-for-next-line
     @fancy_inspect Application.get_env(:tempus, :fancy_inspect, false)
 
-    def inspect(%Tempus.Slot{from: from, to: to}, opts) do
+    def inspect(%Tempus.Slot{from: from, to: to}, %Inspect.Opts{custom_options: [_ | _]} = opts) do
       opts.custom_options
       |> Keyword.get(:fancy, @fancy_inspect)
-      |> if do
-        value =
-          [from, to]
-          |> Enum.map(&DateTime.to_iso8601/1)
-          |> Enum.join(" → ")
+      |> case do
+        truthy when truthy in [:emoji, true] ->
+          value =
+            [from, to]
+            |> Enum.map(&DateTime.to_iso8601/1)
+            |> Enum.join(" → ")
 
-        concat(["⌚<", value, ">"])
-      else
-        concat(["#Slot<", to_doc([from: from, to: to], opts), ">"])
+          tag =
+            case truthy do
+              :emoji -> "⌚"
+              true -> "#Slot"
+            end
+
+          concat([tag, "<", value, ">"])
+
+        _ ->
+          concat(["#Slot<", to_doc([from: from, to: to], opts), ">"])
       end
+    end
+
+    def inspect(%Tempus.Slot{from: from, to: to}, opts) do
+      concat(["#Slot<", to_doc([from: from, to: to], opts), ">"])
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -94,7 +94,6 @@ defmodule Tempus.MixProject do
   defp compilers(_), do: [:telemetria | Mix.compilers()]
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(:ci), do: ["lib", "test/support"]
   defp elixirc_paths(:dev), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/tempus_sigils_test.exs
+++ b/test/tempus_sigils_test.exs
@@ -20,6 +20,7 @@ defmodule Tempus.Sigils.Test do
 
   test "fancy inspect" do
     assert capture_io(fn ->
+             # credo:disable-for-next-line
              IO.inspect(~I[2021-03-30]d, custom_options: [fancy: true])
            end) == "⌚<2021-03-30T00:00:00.000000Z → 2021-03-30T23:59:59.999999Z>\n"
   end

--- a/test/tempus_sigils_test.exs
+++ b/test/tempus_sigils_test.exs
@@ -1,0 +1,26 @@
+defmodule Tempus.Sigils.Test do
+  use ExUnit.Case, async: false
+  doctest Tempus.Sigils
+
+  alias Tempus.Slot
+  import Tempus.Sigils
+  import ExUnit.CaptureIO
+
+  test "sigils" do
+    assert ~I[2021-03-30]d == %Slot{
+             from: ~U[2021-03-30 00:00:00.000000Z],
+             to: ~U[2021-03-30 23:59:59.999999Z]
+           }
+
+    assert ~I[07:23:06]t == %Slot{
+             from: ~U[2021-03-30 07:23:06Z],
+             to: ~U[2021-03-30 07:23:06Z]
+           }
+  end
+
+  test "fancy inspect" do
+    assert capture_io(fn ->
+             IO.inspect(~I[2021-03-30]d, custom_options: [fancy_inspect: true])
+           end) == "⌚<2021-03-30T00:00:00.000000Z → 2021-03-30T23:59:59.999999Z>\n"
+  end
+end

--- a/test/tempus_sigils_test.exs
+++ b/test/tempus_sigils_test.exs
@@ -20,7 +20,7 @@ defmodule Tempus.Sigils.Test do
 
   test "fancy inspect" do
     assert capture_io(fn ->
-             IO.inspect(~I[2021-03-30]d, custom_options: [fancy_inspect: true])
+             IO.inspect(~I[2021-03-30]d, custom_options: [fancy: true])
            end) == "⌚<2021-03-30T00:00:00.000000Z → 2021-03-30T23:59:59.999999Z>\n"
   end
 end

--- a/test/tempus_sigils_test.exs
+++ b/test/tempus_sigils_test.exs
@@ -22,6 +22,11 @@ defmodule Tempus.Sigils.Test do
     assert capture_io(fn ->
              # credo:disable-for-next-line
              IO.inspect(~I[2021-03-30]d, custom_options: [fancy: true])
+           end) == "#Slot<2021-03-30T00:00:00.000000Z → 2021-03-30T23:59:59.999999Z>\n"
+
+    assert capture_io(fn ->
+             # credo:disable-for-next-line
+             IO.inspect(~I[2021-03-30]d, custom_options: [fancy: :emoji])
            end) == "⌚<2021-03-30T00:00:00.000000Z → 2021-03-30T23:59:59.999999Z>\n"
   end
 end

--- a/test/tempus_test.exs
+++ b/test/tempus_test.exs
@@ -1,5 +1,5 @@
 defmodule Tempus.Test do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Tempus
   doctest Tempus.Slot
   doctest Tempus.Slots


### PR DESCRIPTION
* optional fancy inspect via `custom_options: [fancy_inspect: true]
* `wrap(slot)` in `join/1`