### PR TITLE
Refactoring of guard usage

### DIFF
--- a/.dialyzer/ignore.exs
+++ b/.dialyzer/ignore.exs
@@ -1,5 +1,5 @@
 [
-  {"lib/tempus.ex", :no_return, 648},
+  {"lib/tempus.ex", :no_return, 651},
   {"lib/tempus/slots/stream.ex", :call, 430},
   {"lib/tempus/slots/stream.ex", :extra_range, 386}
 ]

--- a/lib/guards.ex
+++ b/lib/guards.ex
@@ -578,7 +578,11 @@ defmodule Tempus.Guards do
                      (is_datetime(o) and is_datetime_covered(o, s)))
 
   @doc """
-  Guard to compare two instances of `t:Tempus.Slot.origin/0`
+  Guard to compare two instances of `t:Tempus.Slot.origin/0`.
+
+  Beware this guards returns a meaningful `true`/`false` if and only all the input types
+    are correct. When passing not `t:Slot.origin/0` as any of parameter it would
+    return `false` and therefore it’s negation is tricky.
 
   ## Examples
 
@@ -632,12 +636,12 @@ defmodule Tempus.Guards do
   """
   def joint_in_delta?(s1, s2, _delta) when is_joint(s1, s2), do: true
 
-  def joint_in_delta?(s1, s2, delta) when is_coming_before(s2, s1) do
+  def joint_in_delta?(s1, s2, delta) when is_slot_coming_before(s2, s1) do
     joint_in_delta?(s2, s1, delta)
   end
 
   def joint_in_delta?(s1, s2, [{unit, delta}])
-      when is_coming_before(s1, s2),
+      when is_slot_coming_before(s1, s2),
       do: abs(DateTime.diff(s1.to, s2.from, unit)) <= delta
 
   def joint_in_delta?(s1, s2, delta_seconds), do: joint_in_delta?(s1, s2, second: delta_seconds)

--- a/lib/tempus.ex
+++ b/lib/tempus.ex
@@ -258,7 +258,7 @@ defmodule Tempus do
       ...>   Tempus.Slot.wrap(~D|2020-08-10|)
       ...> ] |> Enum.into(%Tempus.Slots{})
       iex> slots
-      ...> |> Tempus.drop_while(&is_coming_before(&1, Tempus.Slot.wrap(~D|2020-08-09|)))
+      ...> |> Tempus.drop_while(&is_slot_coming_before(&1, Tempus.Slot.wrap(~D|2020-08-09|)))
       ...> |> Enum.count()
       1
   """
@@ -279,7 +279,7 @@ defmodule Tempus do
       ...>   Tempus.Slot.wrap(~D|2020-08-10|)
       ...> ] |> Enum.into(%Tempus.Slots{})
       iex> slots
-      ...> |> Tempus.take_while(&is_coming_before(&1, Tempus.Slot.wrap(~D|2020-08-09|)))
+      ...> |> Tempus.take_while(&is_slot_coming_before(&1, Tempus.Slot.wrap(~D|2020-08-09|)))
       ...> |> Enum.count()
       1
   """
@@ -411,7 +411,7 @@ defmodule Tempus do
 
   def next_busy(%Slots{} = slots, opts) do
     {origin, count, iterator} = options(opts)
-    do_next_busy(slots, origin, count, iterator)
+    do_next_busy(slots, Slot.wrap(origin), count, iterator)
   end
 
   defp do_next_busy(slots, origin, :infinity, 1) do
@@ -435,7 +435,7 @@ defmodule Tempus do
     |> Enum.take(2)
     |> then(fn
       [_, joint] when is_joint(joint, origin) -> joint
-      [slot | _] when is_coming_before(slot, origin) -> slot
+      [slot | _] when is_slot_coming_before(slot, origin) -> slot
       _ -> nil
     end)
   end

--- a/lib/tempus/slots/normalizers.ex
+++ b/lib/tempus/slots/normalizers.ex
@@ -28,6 +28,8 @@ defmodule Tempus.Slots.Normalizers do
 
   def to_locator(%Slot{} = slot, false) do
     fn other ->
+      other = Slot.wrap(other)
+
       case {is_slot_coming_before(slot, other), is_slot_coming_before(other, slot)} do
         {false, false} -> :eq
         {true, false} -> :gt


### PR DESCRIPTION
- stricter usage of `is_coming_before/2` to avoid issues with its negation
- stricter `t:Tempus.Slot.origin/0` type
- docs improvements